### PR TITLE
added failing test, where round brackets are incorrectly removed/missing

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -257,6 +257,16 @@ test('Episodes', function () {
 			var s;
 		`))
 	});
+
+	test('vec3 permute(vec3 x) { return mod289(((x*34.0)+1.0)*x);}', function () {
+		var compile = GLSL();
+
+		assert.equal(clean(compile(this.title)), clean(`
+			function permute (x) {
+				return mod289([(x[0] * 34.0 + 1.0) * x[0], (x[1] * 34.0 + 1.0) * x[1], (x[2] * 34.0 + 1.0) * x[2]]);
+			};
+		`))
+	});
 });
 
 


### PR DESCRIPTION
I tried to transpile glsl-noise, and found a bug. Here's a test that shows the problem. I tried to fix it myself, but I haven't found where the error occurs yet - simpler cases with just the expression seem to correctly retain the brackets.