### PR TITLE
mat none init bug

### DIFF
--- a/lib/descriptor.js
+++ b/lib/descriptor.js
@@ -74,7 +74,7 @@ function Descriptor (str, options) {
 	else if (descriptor.components == null) {
 		descriptor.components = [];
 		var l = types[descriptor.type].length;
-		if (/mat/.test(descriptor.type)) l *= types[types[type].type].length;
+		if (/mat/.test(descriptor.type)) l *= types[types[descriptor.type].type].length;
 		if (l === 1) {
 			descriptor.components = [descriptor];
 		}


### PR DESCRIPTION
If a mat is not inited, there will be a error about "type" not defined. Should be a typo