### PR TITLE
Chained multiplication bug fix

### DIFF
--- a/lib/operators.js
+++ b/lib/operators.js
@@ -44,6 +44,25 @@ var opComplexity = {
 
 var opsRE = /\*|\+|\-|\/|\%|\<|\=|\>|\&|\||\!|\^|\~/;
 
+/**
+ * Check if expression is protected by parentheses
+ */
+function isProtected (exp) {
+	if (/\s/.test(exp)) {
+		// a + b
+		if (exp[0] !== '(') return false;
+
+		var level = 1;
+		var len = exp.length;
+		for (let i = 1; i < len - 1; i++) {
+			if (exp[i] === '(') level++;
+			else if (exp[i] === ')') level--;
+			// (a + b) * c + d
+			if (level === 0) return false;
+		}
+	}
+	return true;
+}
 
 /**
  * Return rendered operation
@@ -287,7 +306,7 @@ function processOperation (left, right, operator) {
 
 			// embrace complex operators
 			if (operator != '+' && operator != '-') {
-				if (/\s/.test(left) && left[0] != '(' && left[left.length - 1] != ')') opResult += '(' + left + ')'
+				if (!isProtected(left)) opResult += '(' + left + ')'
 				else opResult += left
 			}
 			else opResult += left
@@ -295,7 +314,7 @@ function processOperation (left, right, operator) {
 			opResult += ' ' + operator + ' '
 
 			if (operator != '+' && operator != '-') {
-				if (/\s/.test(right) && right[0] != '(' && right[right.length - 1] != ')') opResult += '(' + right + ')'
+				if (!isProtected(right)) opResult += '(' + right + ')'
 				else opResult += right
 			}
 			else opResult += right

--- a/test/index.js
+++ b/test/index.js
@@ -927,7 +927,21 @@ test('Vec/matrix operators', function () {
 		var a = [1, 0, 0, 1], b = [1, 0, 0, 1], c = [1, 0, 0, 1];
 		gl_Position = [(a[0] * b[0] + a[2] * b[1]) * c[0] + (a[0] * b[2] + a[2] * b[3]) * c[1], (a[1] * b[0] + a[3] * b[1]) * c[0] + (a[1] * b[2] + a[3] * b[3]) * c[1], (a[0] * b[0] + a[2] * b[1]) * c[2] + (a[0] * b[2] + a[2] * b[3]) * c[3], (a[1] * b[0] + a[3] * b[1]) * c[2] + (a[1] * b[2] + a[3] * b[3]) * c[3]];
 		`))
-	})
+	});
+
+	test(`mat * mat * mat * vec`, function () {
+		var compile = GLSL({includes: false});
+
+		assert.equal(clean(compile(`
+		mat2 a, b, c;
+		vec2 d;
+		gl_Position = a * b * c * d;
+		`)), clean(`
+		var a = [1, 0, 0, 1], b = [1, 0, 0, 1], c = [1, 0, 0, 1];
+		var d = [0, 0];
+		gl_Position = [((a[0] * b[0] + a[2] * b[1]) * c[0] + (a[0] * b[2] + a[2] * b[3]) * c[1]) * d[0] + ((a[0] * b[0] + a[2] * b[1]) * c[2] + (a[0] * b[2] + a[2] * b[3]) * c[3]) * d[1], ((a[1] * b[0] + a[3] * b[1]) * c[0] + (a[1] * b[2] + a[3] * b[3]) * c[1]) * d[0] + ((a[1] * b[0] + a[3] * b[1]) * c[2] + (a[1] * b[2] + a[3] * b[3]) * c[3]) * d[1]];
+		`))
+	});
 });
 
 


### PR DESCRIPTION
Fix bug in multiplying 4+ items.

When multiplying left: `(a[0] * b[0] + a[2] * b[1]) * c[0] + (a[0] * b[2] + a[2] * b[3]) * c[1]` with right: `d[0]`

The left is not wrapped with parentheses due to this change: https://github.com/stackgl/glsl-transpiler/commit/d30f40021c6ef5d03a1e3655ff89362620b0057f#diff-1be885155d8e8440371f131e266f97ab


