### PR TITLE
Fix crash in strict mode

### DIFF
--- a/lib/descriptor.js
+++ b/lib/descriptor.js
@@ -35,7 +35,7 @@ function Descriptor (str, options) {
 
 	//take over existing info
 	if (str instanceof String) {
-		extend(descriptor, str);
+		extend(descriptor, pick(str, ['type', 'components', 'visible', 'complexity', 'include', 'optimize']));
 	}
 
 	//take over options


### PR DESCRIPTION
Attempting to extend a string with another string leads to the following error

`TypeError: Cannot assign to read only property '0' of object '[object String]'`

if run in strict mode.
